### PR TITLE
Fix preloadTheme() ignoring light mode preference & correct global.css path in Layout.astro

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -189,8 +189,10 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
   function preloadTheme() {
     const userTheme = localStorage.theme;
 
-    if (userTheme === "light" || userTheme === "dark") {
-      toggleTheme(true); // set default to dark theme
+    if (userTheme === "light") {
+      toggleTheme(false);
+    } else if (userTheme === "dark") {
+      toggleTheme(true);
     } else {
       toggleTheme(window.matchMedia("(prefers-color-scheme: dark)").matches);
     }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ const { title, description } = Astro.props;
 <html lang="en">
   <head>
     <Head title={`${title} | ${SITE.TITLE}`} description={description} />
-    <link rel="stylesheet" href="/path/to/your/global.css">
+    <link rel="stylesheet" href="/src/styles/global.css">
   </head>
   <body>
     <Header />


### PR DESCRIPTION
- Fixed `preloadTheme()` in `Head.astro` to properly apply the stored theme, preventing it from defaulting to dark mode when the user preference is light.
- Corrected the `href` path for `global.css` in `Layout.astro`.